### PR TITLE
Fix code coverage

### DIFF
--- a/koine-test_runner.gemspec
+++ b/koine-test_runner.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.14.1'
-  spec.add_development_dependency 'coveralls', '~> 0.8.21'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'object_comparator', '~> 0.1.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,13 @@
-if ENV['SKIP_COVERAGE'] == 'true'
-  puts "Skipping coverage"
-else
-  require 'simplecov'
-  require 'coveralls'
+require 'bundler/setup'
+require 'object_comparator/rspec'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-    [
-      SimpleCov::Formatter::HTMLFormatter,
-      Coveralls::SimpleCov::Formatter
-    ]
-  )
+require 'simplecov'
 
-  SimpleCov.start do
-    add_filter './spec/'
-  end
+SimpleCov.start do
+  add_filter "/spec/"
 end
 
-require 'bundler/setup'
 require 'koine/test_runner'
-require 'object_comparator/rspec'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION


Some (most?) of my files have been ignored by code coverage. Here is a recent report:

When I run rspec, I get report for only 4 files, the ones marked bellow. 6 other files are ignored. I have no idea why. Even if I set no filter, the files are ignored. Perhaps an internal ignore list of coveralls conflicting with mine?

```bash
lib
└── koine
    ├── test_runner
    │   ├── adapters
    │   │   ├── base_regexp_adapter.rb # covered
    │   │   ├── phpunit.rb             # covered
    │   │   └── rspec.rb               # covered
    │   ├── adapters.rb
    │   ├── builder.rb
    │   ├── command_executer.rb
    │   ├── configuration.rb
    │   ├── file_matcher.rb            # covered
    │   └── version.rb
    └── test_runner.rb
```

<img width="1427" alt="screen shot 2018-03-16 at 10 25 34" src="https://user-images.githubusercontent.com/226834/37513230-c8d815be-2904-11e8-8bca-040c53131b9c.png">

Bellow is the test coverage of all files (no SimpleCov filter)

```ruby
SimpleCov.start do
  # add_filter "/rspec/"
end
```

Note that I do get coverage report for almost all of my spec files but not for all my lib files.

```bash
├── koine
│   ├── test_runner
│   │   ├── adapters
│   │   │   ├── base_regexp_adapter_spec.rb # Exception. Not covered
│   │   │   ├── phpunit_spec.rb
│   │   │   └── rspec_spec.rb
│   │   ├── adapters_spec.rb
│   │   ├── builder_spec.rb
│   │   ├── configuration_spec.rb
│   │   └── file_matcher_spec.rb
│   └── test_runner_spec.rb
```


<img width="1397" alt="screen shot 2018-03-16 at 10 33 23" src="https://user-images.githubusercontent.com/226834/37513545-a880e326-2905-11e8-9937-294ff67c7638.png">
